### PR TITLE
static-container-registry: serve `Docker-Content-Digest` header

### DIFF
--- a/ci/before-install.sh
+++ b/ci/before-install.sh
@@ -14,7 +14,7 @@ After=network.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/bin/containerd --log-level debug
+ExecStart=/usr/bin/containerd
 
 Delegate=yes
 KillMode=process
@@ -39,7 +39,7 @@ cat << EOF | sudo tee /etc/containerd/config.toml
   [plugins.cri]
     [plugins.cri.registry]
       [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."127.0.0.1"]
+        [plugins.cri.registry.mirrors."127.0.0.1:5000"]
           endpoint = ["http://127.0.0.1:5000"]
 EOF
 

--- a/ci/before-install.sh
+++ b/ci/before-install.sh
@@ -2,8 +2,8 @@
 
 set -xue -o pipefail
 
-curl -LO https://github.com/containerd/containerd/releases/download/v1.2.4/containerd-1.2.4.linux-amd64.tar.gz
-tar xvf containerd-1.2.4.linux-amd64.tar.gz
+curl -LO https://github.com/containerd/containerd/releases/download/v1.2.6/containerd-1.2.6.linux-amd64.tar.gz
+tar xvf containerd-1.2.6.linux-amd64.tar.gz
 sudo mv bin/* /usr/bin/
 
 cat << EOF | sudo tee /etc/systemd/system/containerd.service

--- a/test.sh
+++ b/test.sh
@@ -17,12 +17,9 @@ test_docker() {
         done
 }
 
-# containerd relies on the `Docker-Content-Digest` header...
-todo_containerd() {
+test_containerd() {
         for image in ${AVAILABLE_IMAGES[*]}; do
-                sudo ${CRICTL} --image-endpoint unix:///run/containerd/containerd.sock pull "$REGISTRY_HOST/$image"
-                sudo journalctl -u containerd
-                assert false
+                assert "sudo ${CRICTL} --image-endpoint unix:///run/containerd/containerd.sock pull '$REGISTRY/$image'"
         done
 }
 

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,7 @@
 DOCKER=${DOCKER:-$(command -v docker)}
 SKOPEO=${SKOPEO:-$(command -v skopeo)}
 CRICTL=${CRICTL:-$(command -v crictl)}
+CURL=${CURL:-$(command -v curl)}
 IMAGE=${IMAGE:-nicolast/static-container-registry:test}
 IMAGES=/tmp/images
 CONTAINER_NAME=static-container-registry-test
@@ -48,6 +49,18 @@ setup() {
                 -v "$IMAGES:/var/lib/images:ro" \
                 --name "$CONTAINER_NAME" \
                 "$IMAGE" > /dev/null
+
+        local i=100
+        while [ $i -gt 0 ]; do
+                local ok
+                ok=$($CURL --silent http://$REGISTRY/v2/ 2>/dev/null)
+                if [ "x$ok" = 'xok' ]; then
+                        i=0
+                else
+                        sleep 0.1
+                        i=$((i - 1))
+                fi
+        done
 }
 
 teardown() {


### PR DESCRIPTION
It appears `containerd` relies on this header to be present (though
that's not in line with the Docker Distribution spec, which declares
this header to be optional).

This requires us to generate a `location` per manifest, or I guess this
could be implemented using some map/lookup table as well.

See: https://github.com/containerd/containerd/issues/3238
See: https://github.com/containerd/containerd/issues/2994